### PR TITLE
Fixes api.appDeployments.list API url

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -58,7 +58,7 @@ api.appInstances.list = function(appId, configId, cb) {
 }
 
 api.appDeployments.list = function(appId, configId, cb) {
-  var url = urls.api.appInstances.list.replace('{application_id}', appId);
+  var url = urls.api.appDeployments.list.replace('{application_id}', appId);
   helper.sendGetRequest(url, configId, cb);
 }
 


### PR DESCRIPTION
`api.appDeployments.list` was using the `appInstances` URL instead of `appDeployments`.